### PR TITLE
Updates based on Format Review feedback 

### DIFF
--- a/YourName-Dissertation.tex
+++ b/YourName-Dissertation.tex
@@ -85,6 +85,7 @@
 %\documentclass[bs,esc,12pt]{psuthesis}
 
 \usepackage[T1]{fontenc}
+\usepackage[utf8x]{inputenc}
 \usepackage{lmodern}
 \usepackage{textcomp}
 \usepackage{microtype}
@@ -93,6 +94,7 @@
 % Packages I like to use. %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage{amsmath}
+\usepackage{amsfonts}
 \usepackage{amssymb}
 %\usepackage{amsthm}
 %\usepackage{exscale}
@@ -122,7 +124,17 @@
 % who want to use it.
 %
 % To the hyperref package, uncomment the following line:
+% Note that these links will be printed in \textcolor (usually black)
+%\usepackage[hidelinks]{hyperref}
+%
+% If you would prefer colored links instead, uncomment
 %\usepackage{hyperref}
+%\hypersetup{
+%	colorlinks,
+%	linkcolor={red!10!black},
+%	citecolor={blue!50!black},
+%	urlcolor={blue!80!black}
+%}
 %
 % Note that you should also uncomment the following line:
 %\renewcommand{\theHchapter}{\thepart.\thechapter}

--- a/psuthesis.cls
+++ b/psuthesis.cls
@@ -618,7 +618,7 @@ Department Head \\
         \setlength{\psu@intersigspace}{1.5\baselineskip}
     }
     \vspace*{-0.2in}
-    \noindent {\normalsize The \MakeTextLowercase{\psu@documenttype} of \psu@author\ was reviewed and approved$^{*}$ by the following:}\\[3\baselineskip]
+    \noindent {\normalsize The \MakeTextLowercase{\psu@documenttype} of \psu@author\ was reviewed and approved by the following:}\\[3\baselineskip]
 \mbox{}\hfill
 \parbox{\textwidth - 0.5in}{
          \psu@advisor\\[\psu@sigoptionskip]
@@ -760,7 +760,6 @@ Department Head \\
 \mbox{}\vfill
 
 \noindent
-\parbox{\textwidth}{$^{*}$Signatures are on file in the Graduate School.}
 
 \newpage
 }


### PR DESCRIPTION
I've included some changes/updates to the base files, mostly based on dissertation format review feedback. 
There are two sets of changes:

1. Updates to the package setup in `YourName-Dissertation.tex` to tweak the *hyperref* package declaration. The default places red and green boxes around links. These are not acceptable for Format Review. I've added the hidelinks setting (so `\usepackage[hidelinks]{hyperref}`), which leaves the links as black, clickable text, and an alternative option to color the links, but using dark colors (using `\hypersetup`). Both options come from [StackOverflow](https://tex.stackexchange.com/questions/823/remove-ugly-borders-around-clickable-cross-references-and-hyperlinks) (with slightly adjusted colors). I've also added the standard *inputenc* (with the `utf8x` option) and *amsfonts* packages .
2. Removing the "Signatures are on file..." footnote on the signatures page as this is apparently no longer applicable
